### PR TITLE
Switch to using %Y to get the modified time

### DIFF
--- a/radar-base.sh
+++ b/radar-base.sh
@@ -153,7 +153,7 @@ record_timestamp() {
 
 timestamp() {
   if is_repo; then
-    printf '%s' "$($(stat_type) -c%Z "$(dot_git)/lastupdatetime" 2>/dev/null || printf '%s' "0")"
+    printf '%s' "$($(stat_type) -c%Y "$(dot_git)/lastupdatetime" 2>/dev/null || printf '%s' "0")"
   fi
 }
 


### PR DESCRIPTION
The OSX version of stat uses %m to return the 'modified' date since
epoch. The GNU version of stat doesn't have the %m format code.

%Z which was being used in @hallzy's fix returns the 'changed' date
since epoch, which only changes when you modify the metadata on a file.
This meant that when we `touch $dot_git/.lastupdatetime` the 'changed'
date doesn't change.

I've switched to the %Y flag which returns the 'modified' time. This is
the time that is changed when `touch` modifies the file.
